### PR TITLE
Feature/separate tab per fixture status

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,6 +7,7 @@ const config = {
     "@storybook/addon-actions",
     "@storybook/addon-onboarding",
     "@storybook/addon-interactions",
+    "@storybook/addon-viewport",
   ],
   framework: {
     name: "@storybook/react-webpack5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@storybook/addon-viewport": "^7.6.17",
         "@types/google-apps-script": "^1.0.76",
         "body-parser": "^1.20.2",
         "express": "^4.18.2",
@@ -32,6 +31,7 @@
         "@storybook/addon-interactions": "^7.6.5",
         "@storybook/addon-links": "^7.6.5",
         "@storybook/addon-onboarding": "^1.0.10",
+        "@storybook/addon-viewport": "^7.6.17",
         "@storybook/blocks": "^7.6.5",
         "@storybook/react": "^7.6.5",
         "@storybook/react-vite": "^7.6.5",
@@ -6536,6 +6536,7 @@
       "version": "7.6.17",
       "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-7.6.17.tgz",
       "integrity": "sha512-sA0QCcf4QAMixWvn8uvRYPfkKCSl6JajJaAspoPqXSxHEpK7uwOlpg3kqFU5XJJPXD0X957M+ONgNvBzYqSpEw==",
+      "dev": true,
       "dependencies": {
         "memoizerific": "^1.11.3"
       },
@@ -18014,7 +18015,8 @@
     "node_modules/map-or-similar": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg=="
+      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
+      "dev": true
     },
     "node_modules/map-visit": {
       "version": "1.0.0",
@@ -18103,6 +18105,7 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
       "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
+      "dev": true,
       "dependencies": {
         "map-or-similar": "^1.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@storybook/addon-viewport": "^7.6.17",
         "@types/google-apps-script": "^1.0.76",
         "body-parser": "^1.20.2",
         "express": "^4.18.2",
@@ -6413,6 +6414,19 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/addon-essentials/node_modules/@storybook/addon-viewport": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-7.6.5.tgz",
+      "integrity": "sha512-9ghKTaduIUvQ6oShmWLuwMeTjtMR4RgKeKHrTJ7THMqvE/ydDPCYeL7ugF65ocXZSEz/QmxdK7uL686ZMKsqNA==",
+      "dev": true,
+      "dependencies": {
+        "memoizerific": "^1.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/addon-highlight": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-7.6.5.tgz",
@@ -6519,10 +6533,9 @@
       }
     },
     "node_modules/@storybook/addon-viewport": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-7.6.5.tgz",
-      "integrity": "sha512-9ghKTaduIUvQ6oShmWLuwMeTjtMR4RgKeKHrTJ7THMqvE/ydDPCYeL7ugF65ocXZSEz/QmxdK7uL686ZMKsqNA==",
-      "dev": true,
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-7.6.17.tgz",
+      "integrity": "sha512-sA0QCcf4QAMixWvn8uvRYPfkKCSl6JajJaAspoPqXSxHEpK7uwOlpg3kqFU5XJJPXD0X957M+ONgNvBzYqSpEw==",
       "dependencies": {
         "memoizerific": "^1.11.3"
       },
@@ -18001,8 +18014,7 @@
     "node_modules/map-or-similar": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
-      "dev": true
+      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg=="
     },
     "node_modules/map-visit": {
       "version": "1.0.0",
@@ -18091,7 +18103,6 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
       "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
-      "dev": true,
       "dependencies": {
         "map-or-similar": "^1.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "style-loader": "^3.3.3"
   },
   "dependencies": {
+    "@storybook/addon-viewport": "^7.6.17",
     "@types/google-apps-script": "^1.0.76",
     "body-parser": "^1.20.2",
     "express": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@storybook/addon-interactions": "^7.6.5",
     "@storybook/addon-links": "^7.6.5",
     "@storybook/addon-onboarding": "^1.0.10",
+    "@storybook/addon-viewport": "^7.6.17",
     "@storybook/blocks": "^7.6.5",
     "@storybook/react": "^7.6.5",
     "@storybook/react-vite": "^7.6.5",
@@ -61,7 +62,6 @@
     "style-loader": "^3.3.3"
   },
   "dependencies": {
-    "@storybook/addon-viewport": "^7.6.17",
     "@types/google-apps-script": "^1.0.76",
     "body-parser": "^1.20.2",
     "express": "^4.18.2",

--- a/src/frontend/interfaces/pitch/components/PitchView/PitchView.module.scss
+++ b/src/frontend/interfaces/pitch/components/PitchView/PitchView.module.scss
@@ -19,7 +19,6 @@
             text-transform: uppercase;
         }
     }
-
     h2 {
         margin: 0;
         padding: 0;
@@ -27,9 +26,7 @@
         display: grid;
         padding-left: 0 !important;
         padding-right: 0 !important;
-
     }
-
     h2>span:first-child {
         user-select: none;
         margin: 0;
@@ -53,12 +50,6 @@
     }
 
     >div {
-        .fixturesHead {
-            position: fixed;
-            top: 7rem;
-            left: 0;
-            right: 0;
-        }
         >div.fixturesBody {
             margin: 4rem 2rem;
         }

--- a/src/frontend/interfaces/pitch/components/PitchView/PitchView.stories.jsx
+++ b/src/frontend/interfaces/pitch/components/PitchView/PitchView.stories.jsx
@@ -3,26 +3,22 @@ import React from 'react';
 import PitchView from './';
 import '~/src/frontend/shared/css/site.scss';
 
-const PhoneHolder = (props) => {
-  const phoneStyle = {
-    left :'0',
-    top: '0',
-    width: '800px',
-    height: '1200px',
-    position: 'absolute',
-    border: '4px dotted red',
-  }
+const Page = (props) => {
   return (
-    <div style={phoneStyle}>
-        <PitchView {...props} />
+    <div id='app'>
+      <h1>Mock Coordinator</h1>
+      <PitchView {...props} />
     </div>
   )
 }
+
 export default {
   title: 'pitch/PitchView',
-  component: PhoneHolder,
+  component: Page,
   parameters: {
-    layout: 'centered',
+    viewport: {
+      defaultViewport: 'iphonex',
+    }
   },
   tags: ['autodocs'],
 }

--- a/src/frontend/interfaces/pitch/components/PitchView/PitchViewHeader/PitchViewHeader.module.scss
+++ b/src/frontend/interfaces/pitch/components/PitchView/PitchViewHeader/PitchViewHeader.module.scss
@@ -1,0 +1,28 @@
+@import "~/src/frontend/shared/css/_colors.scss";
+
+.fixturesHead {
+    position: fixed;
+    top: 7rem;
+    left: 0;
+    right: 0;
+}
+
+.navBar {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  >span {
+    border: 2px solid darken(white, 30%);
+    background: white;
+    color: black;
+    font-size: 1.1rem;
+    text-align: center;
+    text-transform: uppercase;
+    padding: 1.2rem 0.8rem;
+    border-bottom: 4px solid red;
+  }
+  >span.selected {
+    color: red;
+    border: 2px solid red;
+    border-bottom: none;
+  }
+}

--- a/src/frontend/interfaces/pitch/components/PitchView/PitchViewHeader/PitchViewHeader.stories.jsx
+++ b/src/frontend/interfaces/pitch/components/PitchView/PitchViewHeader/PitchViewHeader.stories.jsx
@@ -1,0 +1,21 @@
+import PitchViewHeader from './';
+import '~/src/frontend/shared/css/site.scss';
+
+export default {
+  title: 'pitch/PitchView/Header',
+  component: PitchViewHeader,
+  parameters: {
+    layout: 'centered',
+    viewport: {
+      defaultViewport: 'iphonex',
+    }
+  },
+  tags: ['autodocs'],
+}
+export const HeaderNavigation = {
+  args: {
+    backToSelection: () => {},
+    changeTab: () => console.log('Changing tab')
+  },
+};
+

--- a/src/frontend/interfaces/pitch/components/PitchView/PitchViewHeader/index.js
+++ b/src/frontend/interfaces/pitch/components/PitchView/PitchViewHeader/index.js
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import styles from "./PitchViewHeader.module.scss";
+
+const PitchViewHeader = ({ pitchId, tab = "Next", backToSelection, changeTab }) => {
+  const tabNames = ["Next", "Finished", "Unplayed"];
+  const [currentTab, setCurrentTab] = useState(tab);
+
+  const tabSelected = tab => {
+    setCurrentTab(tab)
+    changeTab(tab)
+  }
+  return (
+    <div className={styles.fixturesHead}>
+      <h2>
+        <span onClick={backToSelection}></span>
+        <span>Fixtures for pitch: {pitchId}</span>
+      </h2>
+
+      <div className={styles.navBar}>
+        {tabNames.map((tn, i) => (
+          <span
+            id={`tn${i}`}
+            onClick={tabSelected.bind(null, tn)}
+            className={`tab-${tn} ${tn === currentTab ? styles.selected : ""}`}
+          >
+            {tn}
+          </span>
+        ))}{" "}
+      </div>
+    </div>
+  );
+};
+
+export default PitchViewHeader;

--- a/src/frontend/interfaces/pitch/components/PitchView/index.js
+++ b/src/frontend/interfaces/pitch/components/PitchView/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import API from "../../../../shared/api/pitch";
 import Fixture from "./Fixture";
+import PitchViewHeader from './PitchViewHeader';
 import UpdateFixture from "./UpdateFixture";
 import styles from "./PitchView.module.scss";
 
@@ -59,21 +60,13 @@ const PitchView = ({ backToSelection }) => {
     showLater: () => setShowLater(!showLater),
   };
 
-  useEffect(() => {
-    actions.fetchFixtures();
-  }, []);
-
+  useEffect(actions.fetchFixtures);
   return (
     <div className={styles.pitchView}>
-      <div className={styles.fixturesHead}>
-        <h2>
-          <span onClick={backToSelection}></span>
-          <span>Fixtures for pitch: {pitchId}</span>
-        </h2>
-      </div>
+      <PitchViewHeader pitchId={pitchId} backToSelection={backToSelection} />  
       <div className={styles.fixturesBody}>
         <button onClick={actions.showEarlier}>
-          {showEarlier ? "Hide" : "Show"} Earlier Fixturez
+          {showEarlier ? "Hide" : "Show"} Earlier Fixtures
         </button>
         <div className={styles.fixturesArea}>
           {fixtures.map((fixture, i) => {


### PR DESCRIPTION
When navigating fixtures in pitch view, it should show only the next match by default and played and unplayed games in the next tabs.